### PR TITLE
Allow file uploads from the browser

### DIFF
--- a/src/bynder-js-sdk.js
+++ b/src/bynder-js-sdk.js
@@ -135,9 +135,11 @@ const bodyTypes = {
     get: (body) => {
         if (typeof Buffer !== 'undefined' && Buffer.isBuffer(body)) {
             return bodyTypes.BUFFER;
-        } else if (typeof window !== 'undefined' && window.Blob && body instanceof window.Blob) {
+        }
+        if (typeof window !== 'undefined' && window.Blob && body instanceof window.Blob) {
             return bodyTypes.BLOB;
-        } else if (typeof body.read === 'function') {
+        }
+        if (typeof body.read === 'function') {
             return bodyTypes.STREAM;
         }
         return null;
@@ -153,7 +155,8 @@ function getLength(file) {
     const bodyType = bodyTypes.get(body);
     if (bodyType === bodyTypes.BUFFER) {
         return body.length;
-    } else if (bodyType === bodyTypes.BLOB) {
+    }
+    if (bodyType === bodyTypes.BLOB) {
         return body.size;
     }
     return length;


### PR DESCRIPTION
Extends the current uploadFile method from handling Node Buffers/Streams to also working with HTML 5 Blobs, and by extension, Files. 

However note that currently the CORS headers on the relevant endpoints do not appear to allow cross origin requests, so to upload a file from a browser, cross origin restrictions need to be disabled (hence this change essentially remains proof of concept at this point).

N.B. There are extensive failures when I run the test suite, however they are also present when run in the master branch, so I have not attempted to resolve them before making the PR.