### PR TITLE
Add Missing Body Message into Error Promise

### DIFF
--- a/src/bynder-js-sdk.js
+++ b/src/bynder-js-sdk.js
@@ -84,7 +84,8 @@ class APICall {
             if (response.status >= 400) { // check for 4XX, 5XX, wtv
                 return Promise.reject({
                     status: response.status,
-                    message: response.statusText
+                    message: response.statusText,
+                    body: response.data
                 });
             }
             if (response.status >= 200 && response.status <= 202) {


### PR DESCRIPTION
When API returns error informations into Body encoded as JSON. These informations are not forwarded by the SDK.