### PR TITLE
Add possibility to define upload max attempts through env variable

### DIFF
--- a/src/bynder-js-sdk.js
+++ b/src/bynder-js-sdk.js
@@ -811,7 +811,9 @@ class Bynder {
    */
   waitForUploadDone(importIds) {
     const POLLING_INTERVAL = 2000;
-    const MAX_POLLING_ATTEMPTS = 60;
+    const MAX_POLLING_ATTEMPTS = typeof process === 'object'
+      ? process.env.BYNDER_MAX_POLLING_ATTEMPTS || 60 
+      : 60;
     const pollUploadStatus = this.pollUploadStatus.bind(this);
     return new Promise((resolve, reject) => {
       let attempt = 0;


### PR DESCRIPTION
To aid my problems introduced in #42, I created a env variable to have more control over the timeout of asset uploads.