### PR TITLE
Use native baseUrl and params axios config

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "is-url": "^1.2.4",
     "isomorphic-form-data": "^1.0.0",
     "node-fetch": "^1.6.0",
-    "proper-url-join": "^1.2.0",
     "query-string": "^6.1.0",
     "simple-oauth2": "^2.5.1"
   },

--- a/src/bynder-js-sdk.js
+++ b/src/bynder-js-sdk.js
@@ -2,7 +2,6 @@ require("isomorphic-form-data");
 const axios = require("axios");
 const { basename } = require("path");
 const isUrl = require("is-url");
-const joinUrl = require("proper-url-join");
 const queryString = require("query-string");
 const simpleOAuth2 = require("simple-oauth2");
 const url = require("url");
@@ -50,8 +49,6 @@ class APICall {
    * data or an Error with the problem.
    */
   async send(method, url, data = {}) {
-    let callURL = joinUrl(this.baseURL, url, { trailingSlash: true });
-
     const headers = {};
 
     if (!this.token && !this.permanentToken) {
@@ -69,20 +66,23 @@ class APICall {
     }
 
     let body = "";
+    let params = null;
 
     if (method === "POST") {
       headers["Content-Type"] = "application/x-www-form-urlencoded";
 
       body = queryString.stringify(data);
     } else if (Object.keys(data).length && data.constructor === Object) {
-      callURL = joinUrl(callURL, { trailingSlash: true, query: data });
+      params = data;
     }
 
-    return axios(callURL, {
+    return axios(url, {
+      baseURL: this.baseURL,
       httpsAgent: this.httpsAgent,
       httpAgent: this.httpAgent,
       method,
       data: body,
+      params,
       headers
     }).then(response => {
       if (response.status >= 400) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5422,12 +5422,6 @@ prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
-proper-url-join@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/proper-url-join/-/proper-url-join-1.2.0.tgz#4c87d5e5a00e576963226f5a4db09a4eafe419c7"
-  dependencies:
-    query-string "^5.0.1"
-
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -5488,14 +5482,6 @@ qs@^6.4.0:
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-
-query-string@^5.0.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
-  dependencies:
-    decode-uri-component "^0.2.0"
-    object-assign "^4.1.0"
-    strict-uri-encode "^1.0.0"
 
 query-string@^6.1.0:
   version "6.9.0"
@@ -6307,10 +6293,6 @@ stream-http@^2.7.2:
 stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
-
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
 strict-uri-encode@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This resolves an issue for people using bynder-js-sdk as well as axios 0.19.2
Axios 0.19.2 adds a trailing slash after url, therefore putting query params directly in url will generate wrong urls (e.g.: `https://my-url.com/?key=params/`)
Using native "params" axios config should do the trick.
I also make use of native "baseUrl" axios config while I'm at it, so that proper-url-join package can be removed.