### PR TITLE
Add method for getting metaproperty options

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ bynder
 - `saveNewMetapropertyOption(object)`
 - `editMetapropertyOption(object)`
 - `deleteMetapropertyOption(object)`
+- `getMetapropertyOptions(queryObject)`
 
 ### Collections
 

--- a/src/bynder-js-sdk.js
+++ b/src/bynder-js-sdk.js
@@ -513,6 +513,18 @@ class Bynder {
     );
   }
 
+  getMetapropertyOptions({ id, ...params } = {}) {
+    if (!id) {
+      return rejectValidation("metaproperty option", "id");
+    }
+
+    return this.api.send("GET", `v4/metaproperties/${id}/options/`, params).then(data => {
+      return Object.keys(data).map(metaproperty => {
+       return data[metaproperty];
+      });
+    });
+  }
+
   /**
    * Get the assets usage information according to the id provided.
    * @see {@link https://bynder.docs.apiary.io/#reference/asset-usage/asset-usage-operations/retrieve-asset-usage|API Call}

--- a/src/bynder-js-sdk.js
+++ b/src/bynder-js-sdk.js
@@ -513,6 +513,15 @@ class Bynder {
     );
   }
 
+  /**
+   * Get options for a metaproperty
+   * @see {@link https://bynder.docs.apiary.io/#reference/metaproperties/metaproperty-option-operations/retrieve-metaproperty-options|API Call}
+   * @param {Object} params={} - An object containing the id of the desired metaproperty and parameters accepted by the
+   * API to narrow the query for options
+   * @param {String} params.id - The id of the desired metaproperty.
+   * @return {Promise} Response - Returns a Promise that, when fulfilled, will either return an Array with the
+   * metaproperties or an Error with the problem.
+   */
   getMetapropertyOptions({ id, ...params } = {}) {
     if (!id) {
       return rejectValidation("metaproperty option", "id");


### PR DESCRIPTION
Hello! I noticed that [this endpoint](https://bynder.docs.apiary.io/#reference/metaproperties/metaproperty-option-operations/retrieve-metaproperty-options) was not covered here, so I've added a method for it.

I really could not get the SDK to build as-is. I was able to work around this locally, but I wanted to note the issues I observed:
- `babel-loader@6` depends on Babel 7, whereas other modules such as `babel-core` depend on Babel 6
- `webpack@4` is not compatible with the current configuration in the gulpfile (for example, `loaders` should become `rules`)

Please let me know if there's anything more I can do in order to bring in this change! Thank you!
