### PR TITLE
Fix expected token structure on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ const bynder = new Bynder({
   clientId: "<your OAuth2 client id>",
   clientSecret: "<your OAuth2 client secret>",
   redirectUri: "<url where user will be redirected after authenticating>",
-  token: "<OAuth2 access token>"
+  token: {
+    access_token: "<OAuth2 access token>"
+  }
 });
 ```
 


### PR DESCRIPTION
We expect an object with at least an `access_token` property for the JWT. Not a string.