### PR TITLE
[FSB-3476] remove node fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ini": "1.3.7",
     "is-url": "^1.2.4",
     "isomorphic-form-data": "^1.0.0",
-    "node-fetch": "2.6.1",
     "proper-url-join": "^1.2.0",
     "query-string": "6.14.1",
     "simple-oauth2": "^2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5767,11 +5767,6 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"


### PR DESCRIPTION
https://bynder.atlassian.net/browse/FSB-3476

Removed `node-fetch` as it isn't used in the repo.