### PR TITLE
API-2895: Fix opaque TypeError when upload/init returns an invalid response

### DIFF
--- a/src/bynder-js-sdk.js
+++ b/src/bynder-js-sdk.js
@@ -1044,6 +1044,13 @@ class Bynder {
     return Promise.all([getClosestUploadEndpoint(), initUpload(filename)])
       .then(res => {
         const [endpoint, init] = res;
+        if (!init || !init.multipart_params || !init.s3file || !init.s3_filename) {
+          return Promise.reject({
+            status: 0,
+            message: "Upload init returned an unexpected response: missing S3 upload information (multipart_params, s3file, s3_filename). This can happen when the upload/init API call returns an empty or invalid response.",
+            body: init
+          });
+        }
         return uploadFileInChunks(file, endpoint, init, progressCallback);
       })
       .then(uploadResponse => {


### PR DESCRIPTION
uploadFile accessed init.multipart_params.key (and later init.s3file) without validating the upload/init response. When the API intermittently returns an empty or unexpected body, consumers got:

  TypeError: Cannot read properties of undefined (reading 'key')

Validate the init response upfront and reject with a descriptive error including the received body instead.